### PR TITLE
Linux 3.16.36 krun initial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -842,6 +842,7 @@ export mod_sign_cmd
 
 ifeq ($(KBUILD_EXTMOD),)
 core-y		+= kernel/ mm/ fs/ ipc/ security/ crypto/ block/
+core-y		+= krun/
 
 vmlinux-dirs	:= $(patsubst %/,%,$(filter %/, $(init-y) $(init-m) \
 		     $(core-y) $(core-m) $(drivers-y) $(drivers-m) \

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# The Krun Linux Kernel
+
+This repo houses the customised Linux Kernel for use with the
+[Krun Benchmarking System](https://github.com/softdevteam/krun).
+
+This kernel has additional system calls for low-latency access to several MSRs
+which Krun uses for benchmarking. Although the existing `msr' (and `rmsr')
+modules provide access to MSRs via device nodes, they introduce too much jitter
+into measurements.
+
+## Setup and Installation
+
+This section describes the setup of the Krun kernel, including putting the
+kernel into `full tickless mode', which Krun insists upon.
+
+### Step 1: Get the Code and Switch to the Right Branch
+
+First find the right branch of this repo for your needs. We have made a branch
+stemming from each upstream stable release tag for which we wish to support
+Krun on.
+
+So far we only support the Kernel version shipped with Debian 8, which is
+version 3.16.36.
+
+The patched code for 3.16.36 is stored in the `linux-3.16.36-krun` branch. Make
+sure you are in this branch with `git checkout linux-3.16.36-krun`.
+
+### Step 2: Configure and Build the Kernel
+
+Krun insists the kernel is running in "full tickless mode", thus minimising
+regular tick interrupts where possible (for all but the boot CPU core).
+
+The kernel installation process varys depending on the Linux distribution. We
+assume you will be using Debian, since this is the Linux distribution Krun is
+designed to run on.
+
+On a Debian machine, the easiest way to build the kernel, and to have the
+custom headers installed in the right place, is to build and installi deb
+packages.
+
+ * Whilst running the stock Debian kernel (the configuration from the new
+   kernel is inherited from the running kernel), run `make menuconfig` in the
+   top-level directory of this repo.
+
+ * Go into `General setup->Timers subsystem->Timer tick handling` and choose
+   `Full dynticks system (tickless)` (internally known as `CONFIG_NO_HZ_FULL`).
+
+ * Then go up one level and select `Full dynticks system on all CPUs by default
+   (except CPU 0)` (internally `NO_HZ_FULL_ALL`).
+
+ * Go back to the top-level menu and find `General setup->Local Version` and
+   type in a meaningful name. As tempting as it is, *do not* use symbols in
+   this name, as it will cause the Debian package build to bomb out. This name
+   will help you identify if the system is running your kernel.
+
+ * Save and exit.
+
+ * Run `make`
+
+ * Run `make deb-pkg`
+
+## Step 3: Install and Boot the New Kernel
+
+The previous step should have created deb packages in the parent directory. Next:
+
+ * Install them with `dpkg -i <files>`, where `<files>` are the deb packages
+   you want to install. You will need to install the: `linux-firmware-image`,
+   `linux-headers` and `linux-libc-dev` packages (whose exact names will vary).
+
+ * Reboot the system and check the kernel is running with `uname -r`. Debian
+   should have set the kernel as the default, but sometimes (for unknown
+   reasons) it doesn't. If it has not selected your kernel, you need to edit
+   `/etc/default/grub` and run `update-grub` before rebooting.
+
+## Step 3: Check the Kernel Over
+
+Now you are running the Krun kernel. Let's check it all looks OK:
+
+ * Check the kernel is fully tickless with `grep NO_HZ_FULL_ALL
+   /boot/config-\`uname -r\``. You should see `CONFIG_NO_HZ_FULL_ALL=y` in the
+   output.
+
+ * Use `grep -r krun /usr/include`. There should be some system call numbers
+   defined, starting `__NR_krun_` .
+
+ * Check the syscalls work with `cd krun && make && ./test_prog` (in the
+   top-level of this repo). This runs a program which resets the MSRs and
+   prints them every so often. The counters should increase monotonically
+   (unless you run long enough to see an overflow).
+
+## Further Reading
+
+For more information on tickless mode, see
+[the kernel docs](https://www.kernel.org/doc/Documentation/timers/NO_HZ.txt).
+
+For more information about `make deb-pkg`, see
+[the debian handbook](https://debian-handbook.info/browse/stable/sect.kernel-compilation.html).
+
+If you are having trouble setting your default kernel, [this may help](
+
+## License
+
+See the COPYING file for licensing information.

--- a/arch/x86/syscalls/syscall_64.tbl
+++ b/arch/x86/syscalls/syscall_64.tbl
@@ -323,6 +323,10 @@
 314	common	sched_setattr		sys_sched_setattr
 315	common	sched_getattr		sys_sched_getattr
 316	common	renameat2		sys_renameat2
+317	64	krun_read_msrs		sys_krun_read_msrs
+318	64	krun_reset_msrs		sys_krun_reset_msrs
+319	64	krun_configure		sys_krun_reset_msrs
+
 
 #
 # x32-specific system call numbers start at 512 to avoid cache impact

--- a/include/linux/syscalls.h
+++ b/include/linux/syscalls.h
@@ -867,3 +867,7 @@ asmlinkage long sys_kcmp(pid_t pid1, pid_t pid2, int type,
 			 unsigned long idx1, unsigned long idx2);
 asmlinkage long sys_finit_module(int fd, const char __user *uargs, int flags);
 #endif
+asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
+    u64 *mperfs, u64 *ctr1s);
+asmlinkage void sys_krun_reset_msrs(int n_cores);
+asmlinkage int sys_krun_configure(int n_cores);

--- a/krun/.gitignore
+++ b/krun/.gitignore
@@ -1,0 +1,1 @@
+test_prog

--- a/krun/Makefile
+++ b/krun/Makefile
@@ -1,0 +1,5 @@
+obj-y := krun.o
+
+test_prog: test_prog.c
+clean:
+	rm -f test_prog

--- a/krun/krun.c
+++ b/krun/krun.c
@@ -1,0 +1,216 @@
+/*
+ * System calls for low latency MSR reads.
+ *
+ * Copyright (C) 2017, King's College London.
+ * Authored by Edd Barrett <vext01@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/errno.h>
+#include <linux/smp.h>
+#include <asm/msr.h>
+#include <linux/uaccess.h>
+
+/* protos */
+void krun_read_msrs(void *data);
+void krun_reset_msrs(void *ununsed);
+asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
+    u64 *mperfs, u64 *ctr1s);
+asmlinkage void sys_krun_reset_msrs(int n_cores);
+asmlinkage int sys_krun_configure(int n_cores);
+
+/* MSRs */
+#define IA32_APERF		0xe8
+#define IA32_MPERF		0xe7
+#define IA32_PERF_FIXED_CTR1	0x30a
+#define IA32_FIXED_CTR_CTRL	0x38d
+
+/*
+ * Bitfields of MSR_IA32_FIXED_CTR_CTRL related to fixed counter 1.
+ * AKA, CPU_CLK_UNHLATED.CORE in the Intel manual.
+ */
+// Enable couting in ring 0
+#define EN1_OS		1 << 4
+// Enable counting in higer rings
+#define EN1_USR		1 << 5
+// Enable counting for all core threads (if any)
+#define EN1_ANYTHR	1 << 6
+
+/* For passing args to krun_read_msrs() */
+struct krun_msr_args {
+	u64 aperf;
+	u64 mperf;
+	u64 ctr1;
+	bool ctr1_first;
+};
+
+/*
+ * Take low-latency MSR measurements for the current CPU core.
+ */
+void krun_read_msrs(void *data)
+{
+	u32 hi, lo;
+	struct krun_msr_args *args = (struct krun_msr_args *) data;
+
+	if (args->ctr1_first) {
+		asm volatile(
+		    "rdmsr\n\t"
+		    : "=d" (hi), "=a" (lo)	// out
+		    : "c"(IA32_PERF_FIXED_CTR1) // in
+		    :);				// clobber
+		args->ctr1 = ((u64) hi << 32) | lo;
+	}
+
+	asm volatile(
+	    "rdmsr\n\t"
+	    : "=d" (hi), "=a" (lo)	// out
+	    : "c"(IA32_APERF)		// in
+	    :);				// clobber
+	args->aperf = ((u64) hi << 32) | lo;
+
+	asm volatile(
+	    "rdmsr\n\t"
+	    : "=d" (hi), "=a" (lo)	// out
+	    : "c"(IA32_MPERF)		// in
+	    : );			// clobber
+	args->mperf = ((u64) hi << 32) | lo;
+
+	if (!args->ctr1_first) {
+		asm volatile(
+		    "rdmsr\n\t"
+		    : "=d" (hi), "=a" (lo)	// out
+		    : "c"(IA32_PERF_FIXED_CTR1) // in
+		    :);				// clobber
+		args->ctr1 = ((u64) hi << 32) | lo;
+	}
+}
+
+/* Reset the MSRs of interest on the current CPU core */
+void krun_reset_msrs(void *ununsed)
+{
+    /*
+     * Note we reset MPERF before APERF, so that APERF can never be greater
+     * than MPERF.
+     */
+	asm volatile(
+	    "xor %%eax, %%eax\n\t"
+	    "xor %%edx, %%edx\n\t"
+	    "mov %0, %%ecx\n\t"
+	    "wrmsr\n\t"
+	    "mov %1, %%ecx\n\t"
+	    "wrmsr\n\t"
+	    "mov %2, %%ecx\n\t"
+	    "wrmsr\n\t"
+	    :				// out
+	    : "i"(IA32_MPERF), "i"(IA32_APERF), "i"(IA32_PERF_FIXED_CTR1) // in
+	    :"eax", "ecx", "edx");	// clobber
+}
+
+/* ------------------------
+ * System call entry points
+ * ------------------------
+ */
+
+/*
+ * Read the MSRs for the first n_cores cores and return the values via the
+ * `aperfs', `mperfs' and `ctr1s' arrays.
+ *
+ * The arrays should have been pre-allocated by userspace with enough
+ * space for one 64-bit unsigned integer per-core.
+ *
+ * If `ctr1_first' is true, then read the IA32_PERF_FIXED_CTR1 first, otherwise
+ * it is read last. read them in stop order.
+ *
+ * Assumes no CPU cores have been offlined.
+ *
+ * Returns non-zero on error.
+ */
+asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
+    u64 *mperfs, u64 *ctr1s)
+{
+	struct krun_msr_args args;
+	unsigned long err;
+	int core;
+
+	args.ctr1_first = ctr1_first;
+	for (core = 0; core < n_cores; core++) {
+		// Take readings
+		smp_call_function_single(core, krun_read_msrs, &args, 1);
+
+		// Copy results from kernel memory into userspace virtual memory
+		err = copy_to_user(&aperfs[core], &args.aperf, sizeof(u64));
+		if (err != 0) {
+			printk("copy_to_user failed with %lu\n", err);
+			return -EFAULT;
+		}
+		err = copy_to_user(&mperfs[core], &args.mperf, sizeof(u64));
+		if (err != 0) {
+			printk("copy_to_user failed with %lu\n", err);
+			return -EFAULT;
+		}
+		err = copy_to_user(&ctr1s[core], &args.ctr1, sizeof(u64));
+		if (err != 0) {
+			printk("copy_to_user failed with %lu\n", err);
+			return -EFAULT;
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * Reset the MSRs for the first n_cores cores.
+ */
+asmlinkage void sys_krun_reset_msrs(int n_cores) {
+	int core;
+	for (core = 0; core < n_cores; core++) {
+		smp_call_function_single(core, krun_reset_msrs, (void *) NULL, 1);
+	}
+}
+
+/*
+ * Configure the fixed-function performance counter on the first n_cores cores.
+ *
+ * Returns non-zero on error.
+ */
+asmlinkage int sys_krun_configure(int n_cores) {
+	/*
+	 * Since we dont mind about latency here, we may as well use the helper
+	 * functions provided by <asm/msr.h>.
+	 */
+	u32 hi, lo;
+	int err, core;
+
+	for (core = 0; core < n_cores; core++) {
+		err = rdmsr_safe_on_cpu(core, IA32_FIXED_CTR_CTRL, &lo, &hi);
+		if (err) {
+			printk("problem reading IA32_FIXED_CTR_CTRL\n");
+			return err;
+		}
+
+		/* All of the flags are in the lower 32-bits of the MSR */
+		lo |= (EN1_OS | EN1_USR | EN1_ANYTHR);
+
+		err = wrmsr_safe_on_cpu(core, IA32_FIXED_CTR_CTRL, lo, hi);
+		if (err) {
+			printk("problem writing IA32_FIXED_CTR_CTRL\n");
+			return err;
+		}
+	}
+	return 0;
+}

--- a/krun/test_prog.c
+++ b/krun/test_prog.c
@@ -1,0 +1,139 @@
+#include <stdio.h>
+#include <linux/kernel.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include <err.h>
+#include <asm/unistd.h>
+
+/* protos */
+void read_msrs_checked(int n_cores, bool ctr1_first, u_int64_t *aperfs,
+    u_int64_t *mperfs, u_int64_t *ctr1s);
+u_int64_t **alloc_array(int n_cores);
+void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs, u_int64_t **ctr1s);
+int get_ctr1_width(void);
+void mask_ctr1s(int n_cores, u_int64_t **ctr1s);
+
+/* ctr1 is variable size */
+u_int64_t ctr1_mask = 0;
+
+int get_ctr1_width(void) {
+	uint32_t eax, edx;
+	int width;
+
+	asm volatile(
+	    "mov $0xa, %%eax\n\t"       // pctr leaf
+	    "cpuid\n\t"
+	    : "=a" (eax), "=d" (edx)    // out
+	    :                           // in
+	    : "ebx", "ecx");            // clobber
+	width = (edx & 0x1fe0) >> 5;
+	printf("ctr1 width is %d\n", width);
+	return width;
+}
+
+void read_msrs_checked(int n_cores, bool ctr1_first, u_int64_t *aperfs,
+    u_int64_t *mperfs, u_int64_t *ctr1s)
+{
+	int err = syscall(__NR_krun_read_msrs, n_cores, ctr1_first, aperfs, mperfs, ctr1s);
+	if (err != 0) {
+		printf("syscall returned: %ld\n", err);
+		exit(err);
+    }
+}
+
+/* allocates space for 2 readings of one performance counter for all cores */
+u_int64_t **alloc_array(int n_cores)
+{
+	u_int64_t **arr;
+	int i;
+
+	arr = calloc(2, sizeof(u_int64_t *));
+	if (arr == NULL) {
+		printf("failed to allocate\n");
+		exit(EXIT_FAILURE);
+	}
+
+	for (i = 0; i < 2; i++) {
+		arr[i] = calloc(n_cores, sizeof(u_int64_t));
+		if (arr[i] == NULL) {
+			printf("failed to allocate\n");
+			exit(EXIT_FAILURE);
+		}
+	}
+	return arr;
+}
+
+/* apply masking to ctr1s */
+void mask_ctr1s(int n_cores, u_int64_t **ctr1s)
+{
+	int core;
+
+	for (core = 0; core < n_cores; core++) {
+		ctr1s[0][core] &= ctr1_mask;
+		ctr1s[1][core] &= ctr1_mask;
+	}
+}
+
+/* print before and after readings for all counters */
+void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs, u_int64_t **ctr1s)
+{
+	int core, idx;
+
+	for (idx = 0; idx < 2; idx++) {
+		if (!idx) {
+			printf("Before:\n");
+		} else {
+			printf("After:\n");
+		}
+		for (core = 0; core < n_cores; core++) {
+			printf("  core: %02d: aperf: %016" PRIu64 "    ", core, aperfs[idx][core]);
+			printf("mperf: %016" PRIu64 "    ", mperfs[idx][core]);
+			printf("ctr1 : %016" PRIu64 "\n", ctr1s[idx][core]);
+
+			// check they make sense too
+			if (aperfs[0][core] > aperfs[1][core]) {
+				errx(1, "bad aperfs");
+			}
+			if (mperfs[0][core] > mperfs[1][core]) {
+				errx(1, "bad mperfs");
+			}
+			if (ctr1s[0][core] > ctr1s[1][core]) {
+				errx(1, "bad ctr1");
+			}
+		}
+	}
+}
+
+int main(void)
+{
+	u_int64_t **aperfs, **mperfs, **ctr1s;
+	int core, i, n_cores;
+
+	ctr1_mask = ((u_int64_t) 1 << get_ctr1_width()) - 1;
+	printf("ctr1 mask is %" PRIx64 "\n", ctr1_mask);
+	n_cores = sysconf(_SC_NPROCESSORS_ONLN);
+
+	/* make space for readings */
+	aperfs = alloc_array(n_cores);
+	mperfs = alloc_array(n_cores);
+	ctr1s = alloc_array(n_cores);
+
+	syscall(__NR_krun_configure, n_cores);
+	syscall(__NR_krun_reset_msrs, n_cores);
+
+	// continually read MSRs
+	for (;;) {
+		read_msrs_checked(n_cores, false, aperfs[0], mperfs[0], ctr1s[0]);
+		read_msrs_checked(n_cores, true, aperfs[1], mperfs[1], ctr1s[1]);
+		mask_ctr1s(n_cores, ctr1s);
+		print_arrays(n_cores, aperfs, mperfs, ctr1s);
+		usleep(1 * 1000 * 500);
+		printf("\n");
+	}
+	// unreachable
+	return 0;
+}


### PR DESCRIPTION
Let's start looking at this.

Please don't merge yet. This should be merged at the same time as the Krun branch I'm working on.

This provides three system calls to replace the `rmsr` module in Krun. It seems to have *very* little jitter compared to the `rmsr` approach.

* I think we have to keep the same license as the Linux kernel (GPL2+).

* Note the base branch. This is a (currently empty) branch stemming from the upstream `linux-3.16.36` *tag*. We will have to make one such branch for every kernel version we want to support (eventually Debian 9).

Comments?