### PR TITLE
Linux 4.9 krun dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -911,6 +911,7 @@ export mod_sign_cmd
 
 ifeq ($(KBUILD_EXTMOD),)
 core-y		+= kernel/ certs/ mm/ fs/ ipc/ security/ crypto/ block/
+core-y		+= krun/
 
 vmlinux-dirs	:= $(patsubst %/,%,$(filter %/, $(init-y) $(init-m) \
 		     $(core-y) $(core-m) $(drivers-y) $(drivers-m) \

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # The Krun Linux Kernel
 
-This repo houses the customised Linux Kernel for use with the
+This repo houses the customised Linux-4.9.0 Kernel for use with the
 [Krun Benchmarking System](https://github.com/softdevteam/krun).
 
 This kernel has additional system calls for low-latency access to several MSRs
-which Krun uses for benchmarking. Although the existing `msr' (and `rmsr')
+which Krun uses for benchmarking. Although the existing `msr` (and `rmsr`)
 modules provide access to MSRs via device nodes, they introduce too much jitter
 into measurements.
 
@@ -13,29 +13,30 @@ into measurements.
 This section describes the setup of the Krun kernel, including putting the
 kernel into `full tickless mode', which Krun insists upon.
 
-### Step 1: Get the Code and Switch to the Right Branch
+### Step 1: Make Sure You Are on the Right Branch
 
-First find the right branch of this repo for your needs. We have made a branch
-stemming from each upstream stable release tag for which we wish to support
-Krun on.
+This branch is for kernel version 4.9 (also named 4.9.0).
 
-So far we only support the Kernel version shipped with Debian 8, which is
-version 3.16.36.
+If this is not the version you want, then switch branch. To see which Kernel
+versions we have patched, run:
 
-The patched code for 3.16.36 is stored in the `linux-3.16.36-krun` branch. Make
-sure you are in this branch with `git checkout linux-3.16.36-krun`.
+```
+$ git branch -r | grep krun
+```
+
+Our branches are named `linux-\*-krun`.
 
 ### Step 2: Configure and Build the Kernel
 
 Krun insists the kernel is running in "full tickless mode", thus minimising
 regular tick interrupts where possible (for all but the boot CPU core).
 
-The kernel installation process varys depending on the Linux distribution. We
+The kernel installation process varies depending on the Linux distribution. We
 assume you will be using Debian, since this is the Linux distribution Krun is
 designed to run on.
 
 On a Debian machine, the easiest way to build the kernel, and to have the
-custom headers installed in the right place, is to build and installi deb
+custom headers installed in the right place, is to build and install deb
 packages.
 
  * Whilst running the stock Debian kernel (the configuration from the new
@@ -55,7 +56,7 @@ packages.
 
  * Save and exit.
 
- * Run `make`
+ * Run `make` (for a real benchmarking setup do *not* use `-j`)
 
  * Run `make deb-pkg`
 
@@ -94,9 +95,7 @@ For more information on tickless mode, see
 [the kernel docs](https://www.kernel.org/doc/Documentation/timers/NO_HZ.txt).
 
 For more information about `make deb-pkg`, see
-[the debian handbook](https://debian-handbook.info/browse/stable/sect.kernel-compilation.html).
-
-If you are having trouble setting your default kernel, [this may help](
+[the Debian handbook](https://debian-handbook.info/browse/stable/sect.kernel-compilation.html).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+# The Krun Linux Kernel
+
+This repo houses the customised Linux Kernel for use with the
+[Krun Benchmarking System](https://github.com/softdevteam/krun).
+
+This kernel has additional system calls for low-latency access to several MSRs
+which Krun uses for benchmarking. Although the existing `msr' (and `rmsr')
+modules provide access to MSRs via device nodes, they introduce too much jitter
+into measurements.
+
+## Setup and Installation
+
+This section describes the setup of the Krun kernel, including putting the
+kernel into `full tickless mode', which Krun insists upon.
+
+### Step 1: Get the Code and Switch to the Right Branch
+
+First find the right branch of this repo for your needs. We have made a branch
+stemming from each upstream stable release tag for which we wish to support
+Krun on.
+
+So far we only support the Kernel version shipped with Debian 8, which is
+version 3.16.36.
+
+The patched code for 3.16.36 is stored in the `linux-3.16.36-krun` branch. Make
+sure you are in this branch with `git checkout linux-3.16.36-krun`.
+
+### Step 2: Configure and Build the Kernel
+
+Krun insists the kernel is running in "full tickless mode", thus minimising
+regular tick interrupts where possible (for all but the boot CPU core).
+
+The kernel installation process varys depending on the Linux distribution. We
+assume you will be using Debian, since this is the Linux distribution Krun is
+designed to run on.
+
+On a Debian machine, the easiest way to build the kernel, and to have the
+custom headers installed in the right place, is to build and installi deb
+packages.
+
+ * Whilst running the stock Debian kernel (the configuration from the new
+   kernel is inherited from the running kernel), run `make menuconfig` in the
+   top-level directory of this repo.
+
+ * Go into `General setup->Timers subsystem->Timer tick handling` and choose
+   `Full dynticks system (tickless)` (internally known as `CONFIG_NO_HZ_FULL`).
+
+ * Then go up one level and select `Full dynticks system on all CPUs by default
+   (except CPU 0)` (internally `NO_HZ_FULL_ALL`).
+
+ * Go back to the top-level menu and find `General setup->Local Version` and
+   type in a meaningful name. As tempting as it is, *do not* use symbols in
+   this name, as it will cause the Debian package build to bomb out. This name
+   will help you identify if the system is running your kernel.
+
+ * Save and exit.
+
+ * Run `make`
+
+ * Run `make deb-pkg`
+
+## Step 3: Install and Boot the New Kernel
+
+The previous step should have created deb packages in the parent directory. Next:
+
+ * Install them with `dpkg -i <files>`, where `<files>` are the deb packages
+   you want to install. You will need to install the: `linux-firmware-image`,
+   `linux-headers` and `linux-libc-dev` packages (whose exact names will vary).
+
+ * Reboot the system and check the kernel is running with `uname -r`. Debian
+   should have set the kernel as the default, but sometimes (for unknown
+   reasons) it doesn't. If it has not selected your kernel, you need to edit
+   `/etc/default/grub` and run `update-grub` before rebooting.
+
+## Step 3: Check the Kernel Over
+
+Now you are running the Krun kernel. Let's check it all looks OK:
+
+ * Check the kernel is fully tickless with `grep NO_HZ_FULL_ALL
+   /boot/config-\`uname -r\``. You should see `CONFIG_NO_HZ_FULL_ALL=y` in the
+   output.
+
+ * Use `grep -r krun /usr/include`. There should be some system call numbers
+   defined, starting `__NR_krun_` .
+
+ * Check the syscalls work with `cd krun && make && ./test_prog` (in the
+   top-level of this repo). This runs a program which resets the MSRs and
+   prints them every so often. The counters should increase monotonically
+   (unless you run long enough to see an overflow).
+
+## Further Reading
+
+For more information on tickless mode, see
+[the kernel docs](https://www.kernel.org/doc/Documentation/timers/NO_HZ.txt).
+
+For more information about `make deb-pkg`, see
+[the debian handbook](https://debian-handbook.info/browse/stable/sect.kernel-compilation.html).
+
+If you are having trouble setting your default kernel, [this may help](
+
+## License
+
+See the COPYING file for licensing information.

--- a/arch/x86/entry/syscalls/syscall_64.tbl
+++ b/arch/x86/entry/syscalls/syscall_64.tbl
@@ -338,6 +338,9 @@
 329	common	pkey_mprotect		sys_pkey_mprotect
 330	common	pkey_alloc		sys_pkey_alloc
 331	common	pkey_free		sys_pkey_free
+332	64	krun_read_msrs		sys_krun_read_msrs
+333	64	krun_reset_msrs		sys_krun_reset_msrs
+334	64	krun_configure		sys_krun_configure
 
 #
 # x32-specific system call numbers start at 512 to avoid cache impact

--- a/include/linux/syscalls.h
+++ b/include/linux/syscalls.h
@@ -904,3 +904,7 @@ asmlinkage long sys_pkey_alloc(unsigned long flags, unsigned long init_val);
 asmlinkage long sys_pkey_free(int pkey);
 
 #endif
+asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
+    u64 *mperfs, u64 *ctr1s);
+asmlinkage void sys_krun_reset_msrs(int n_cores);
+asmlinkage int sys_krun_configure(int n_cores);

--- a/krun/.gitignore
+++ b/krun/.gitignore
@@ -1,0 +1,1 @@
+test_prog

--- a/krun/Makefile
+++ b/krun/Makefile
@@ -1,5 +1,6 @@
 obj-y := krun.o
 
 test_prog: test_prog.c
+	${CC} ${CFLAGS} ${LDFLAGS} -Wall -Wextra -o $@ $<
 clean:
 	rm -f test_prog

--- a/krun/Makefile
+++ b/krun/Makefile
@@ -1,0 +1,5 @@
+obj-y := krun.o
+
+test_prog: test_prog.c
+clean:
+	rm -f test_prog

--- a/krun/krun.c
+++ b/krun/krun.c
@@ -26,6 +26,8 @@
 #include <asm/msr.h>
 #include <linux/uaccess.h>
 
+#include "krun_reg.h"
+
 /* protos */
 void krun_read_msrs(void *data);
 void krun_reset_msrs(void *unused);
@@ -34,34 +36,6 @@ asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
 asmlinkage void sys_krun_reset_msrs(int n_cores);
 asmlinkage int sys_krun_configure(int n_cores);
 u8 krun_get_arch_perf_ctr_version(void);
-
-/* MSRs */
-#define IA32_APERF		0xe8
-#define IA32_MPERF		0xe7
-#define IA32_PERF_FIXED_CTR1	0x30a
-#define IA32_FIXED_CTR_CTRL	0x38d
-#define IA32_PERF_GLOBAL_CTRL	0x38f
-
-/*
- * Bitfields of IA32_FIXED_CTR_CTRL related to fixed counter 1.
- * AKA, CPU_CLK_UNHLATED.CORE in the Intel manual.
- */
-// Enable couting in ring 0
-#define EN1_OS		1 << 4
-// Enable counting in higer rings
-#define EN1_USR		1 << 5
-// Enable counting for all core threads (if any)
-#define EN1_ANYTHR	1 << 6
-
-/* Bitfields in the IA32_PERF_GLOBAL_CTRL MSR */
-// Enable IA32_PERF_FIXED_CTR1
-#define EN_FIXED_CTR1	1 << 1  // top 32-bits
-
-/* Archtectural performance counter CPUID leaf */
-#define	CPUID_ARCH_PERF_CTRS	0x0a
-
-/* Bit fields of CPUID_ARCH_PERF_CTRS */
-#define CPUID_ARCH_PERF_CTRS_VERS	0xff
 
 /* For passing args to krun_read_msrs() */
 struct krun_msr_args {

--- a/krun/krun.c
+++ b/krun/krun.c
@@ -1,0 +1,216 @@
+/*
+ * System calls for low latency MSR reads.
+ *
+ * Copyright (C) 2017, King's College London.
+ * Created by the Software Development Team <http://soft-dev.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <linux/kernel.h>
+#include <linux/types.h>
+#include <linux/errno.h>
+#include <linux/smp.h>
+#include <asm/msr.h>
+#include <linux/uaccess.h>
+
+/* protos */
+void krun_read_msrs(void *data);
+void krun_reset_msrs(void *unused);
+asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
+    u64 *mperfs, u64 *ctr1s);
+asmlinkage void sys_krun_reset_msrs(int n_cores);
+asmlinkage int sys_krun_configure(int n_cores);
+
+/* MSRs */
+#define IA32_APERF		0xe8
+#define IA32_MPERF		0xe7
+#define IA32_PERF_FIXED_CTR1	0x30a
+#define IA32_FIXED_CTR_CTRL	0x38d
+
+/*
+ * Bitfields of MSR_IA32_FIXED_CTR_CTRL related to fixed counter 1.
+ * AKA, CPU_CLK_UNHLATED.CORE in the Intel manual.
+ */
+// Enable couting in ring 0
+#define EN1_OS		1 << 4
+// Enable counting in higer rings
+#define EN1_USR		1 << 5
+// Enable counting for all core threads (if any)
+#define EN1_ANYTHR	1 << 6
+
+/* For passing args to krun_read_msrs() */
+struct krun_msr_args {
+	u64 aperf;
+	u64 mperf;
+	u64 ctr1;
+	bool ctr1_first;
+};
+
+/*
+ * Take low-latency MSR measurements for the current CPU core.
+ */
+void krun_read_msrs(void *data)
+{
+	u32 hi, lo;
+	struct krun_msr_args *args = (struct krun_msr_args *) data;
+
+	if (args->ctr1_first) {
+		asm volatile(
+		    "rdmsr\n\t"
+		    : "=d" (hi), "=a" (lo)	// out
+		    : "c"(IA32_PERF_FIXED_CTR1) // in
+		    :);				// clobber
+		args->ctr1 = ((u64) hi << 32) | lo;
+	}
+
+	asm volatile(
+	    "rdmsr\n\t"
+	    : "=d" (hi), "=a" (lo)	// out
+	    : "c"(IA32_APERF)		// in
+	    :);				// clobber
+	args->aperf = ((u64) hi << 32) | lo;
+
+	asm volatile(
+	    "rdmsr\n\t"
+	    : "=d" (hi), "=a" (lo)	// out
+	    : "c"(IA32_MPERF)		// in
+	    : );			// clobber
+	args->mperf = ((u64) hi << 32) | lo;
+
+	if (!args->ctr1_first) {
+		asm volatile(
+		    "rdmsr\n\t"
+		    : "=d" (hi), "=a" (lo)	// out
+		    : "c"(IA32_PERF_FIXED_CTR1) // in
+		    :);				// clobber
+		args->ctr1 = ((u64) hi << 32) | lo;
+	}
+}
+
+/* Reset the MSRs of interest on the current CPU core */
+void krun_reset_msrs(void *unused)
+{
+	/*
+	 * Note we reset MPERF before APERF, so that APERF can never be greater
+	 * than MPERF.
+	 */
+	asm volatile(
+	    "xor %%eax, %%eax\n\t"
+	    "xor %%edx, %%edx\n\t"
+	    "mov %0, %%ecx\n\t"
+	    "wrmsr\n\t"
+	    "mov %1, %%ecx\n\t"
+	    "wrmsr\n\t"
+	    "mov %2, %%ecx\n\t"
+	    "wrmsr\n\t"
+	    :				// out
+	    : "i"(IA32_MPERF), "i"(IA32_APERF), "i"(IA32_PERF_FIXED_CTR1) // in
+	    :"eax", "ecx", "edx");	// clobber
+}
+
+/* ------------------------
+ * System call entry points
+ * ------------------------
+ */
+
+/*
+ * Read the MSRs for the first n_cores cores and return the values via the
+ * `aperfs', `mperfs' and `ctr1s' arrays.
+ *
+ * The arrays should have been pre-allocated by userspace with enough
+ * space for one 64-bit unsigned integer per-core.
+ *
+ * If `ctr1_first' is true, then read the IA32_PERF_FIXED_CTR1 first, otherwise
+ * it is read last.
+ *
+ * Assumes no CPU cores have been offlined.
+ *
+ * Returns non-zero on error.
+ */
+asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
+    u64 *mperfs, u64 *ctr1s)
+{
+	struct krun_msr_args args;
+	unsigned long err;
+	int core;
+
+	args.ctr1_first = ctr1_first;
+	for (core = 0; core < n_cores; core++) {
+		// Take readings
+		smp_call_function_single(core, krun_read_msrs, &args, 1);
+
+		// Copy results from kernel memory into userspace virtual memory
+		err = copy_to_user(&aperfs[core], &args.aperf, sizeof(u64));
+		if (err != 0) {
+			printk("copy_to_user failed with %lu\n", err);
+			return -EFAULT;
+		}
+		err = copy_to_user(&mperfs[core], &args.mperf, sizeof(u64));
+		if (err != 0) {
+			printk("copy_to_user failed with %lu\n", err);
+			return -EFAULT;
+		}
+		err = copy_to_user(&ctr1s[core], &args.ctr1, sizeof(u64));
+		if (err != 0) {
+			printk("copy_to_user failed with %lu\n", err);
+			return -EFAULT;
+		}
+	}
+
+	return 0;
+}
+
+/*
+ * Reset the MSRs for the first n_cores cores.
+ */
+asmlinkage void sys_krun_reset_msrs(int n_cores) {
+	int core;
+	for (core = 0; core < n_cores; core++) {
+		smp_call_function_single(core, krun_reset_msrs, (void *) NULL, 1);
+	}
+}
+
+/*
+ * Configure the fixed-function performance counter on the first n_cores cores.
+ *
+ * Returns non-zero on error.
+ */
+asmlinkage int sys_krun_configure(int n_cores) {
+	/*
+	 * Since we dont mind about latency here, we may as well use the helper
+	 * functions provided by <asm/msr.h>.
+	 */
+	u32 hi, lo;
+	int err, core;
+
+	for (core = 0; core < n_cores; core++) {
+		err = rdmsr_safe_on_cpu(core, IA32_FIXED_CTR_CTRL, &lo, &hi);
+		if (err) {
+			printk("problem reading IA32_FIXED_CTR_CTRL\n");
+			return err;
+		}
+
+		/* All of the flags are in the lower 32-bits of the MSR */
+		lo |= (EN1_OS | EN1_USR | EN1_ANYTHR);
+
+		err = wrmsr_safe_on_cpu(core, IA32_FIXED_CTR_CTRL, lo, hi);
+		if (err) {
+			printk("problem writing IA32_FIXED_CTR_CTRL\n");
+			return err;
+		}
+	}
+	return 0;
+}

--- a/krun/krun.c
+++ b/krun/krun.c
@@ -56,32 +56,32 @@ void krun_read_msrs(void *data)
 	if (args->ctr1_first) {
 		asm volatile(
 		    "rdmsr\n\t"
-		    : "=d" (hi), "=a" (lo)	// out
-		    : "c"(IA32_PERF_FIXED_CTR1) // in
-		    :);				// clobber
+		    : "=d" (hi), "=a" (lo)	/* out */
+		    : "c"(IA32_PERF_FIXED_CTR1) /* in */
+		    :);				/* clobber */
 		args->ctr1 = ((u64) hi << 32) | lo;
 	}
 
 	asm volatile(
 	    "rdmsr\n\t"
-	    : "=d" (hi), "=a" (lo)	// out
-	    : "c"(IA32_APERF)		// in
-	    :);				// clobber
+	    : "=d" (hi), "=a" (lo)	/* out */
+	    : "c"(IA32_APERF)		/* in */
+	    :);				/* clobber */
 	args->aperf = ((u64) hi << 32) | lo;
 
 	asm volatile(
 	    "rdmsr\n\t"
-	    : "=d" (hi), "=a" (lo)	// out
-	    : "c"(IA32_MPERF)		// in
-	    : );			// clobber
+	    : "=d" (hi), "=a" (lo)	/* out */
+	    : "c"(IA32_MPERF)		/* in */
+	    : );			/* clobber */
 	args->mperf = ((u64) hi << 32) | lo;
 
 	if (!args->ctr1_first) {
 		asm volatile(
 		    "rdmsr\n\t"
-		    : "=d" (hi), "=a" (lo)	// out
-		    : "c"(IA32_PERF_FIXED_CTR1) // in
-		    :);				// clobber
+		    : "=d" (hi), "=a" (lo)	/* out */
+		    : "c"(IA32_PERF_FIXED_CTR1) /* in */
+		    :);				/* clobber */
 		args->ctr1 = ((u64) hi << 32) | lo;
 	}
 }
@@ -102,9 +102,10 @@ void krun_reset_msrs(void *unused)
 	    "wrmsr\n\t"
 	    "mov %2, %%ecx\n\t"
 	    "wrmsr\n\t"
-	    :				// out
-	    : "i"(IA32_MPERF), "i"(IA32_APERF), "i"(IA32_PERF_FIXED_CTR1) // in
-	    :"eax", "ecx", "edx");	// clobber
+	    : 					/* out */
+	    : "i"(IA32_MPERF), "i"(IA32_APERF),
+	      "i"(IA32_PERF_FIXED_CTR1)		/* in */
+	    :"eax", "ecx", "edx");		/* clobber */
 }
 
 u8 krun_get_arch_perf_ctr_version()
@@ -114,9 +115,9 @@ u8 krun_get_arch_perf_ctr_version()
 	asm volatile(
 	    "mov %1, %%eax\n\t"
 	    "cpuid\n\t"
-	    : "=a" (eax)			// out
-	    : "i"(CPUID_ARCH_PERF_CTRS) 	// in
-	    :"ebx", "ecx", "edx");		// clobber
+	    : "=a" (eax)			/* out */
+	    : "i"(CPUID_ARCH_PERF_CTRS) 	/* in */
+	    :"ebx", "ecx", "edx");		/* clobber */
 
 	return eax & CPUID_ARCH_PERF_CTRS_VERS;
 }
@@ -149,10 +150,10 @@ asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
 
 	args.ctr1_first = ctr1_first;
 	for (core = 0; core < n_cores; core++) {
-		// Take readings
+		/* Take readings */
 		smp_call_function_single(core, krun_read_msrs, &args, 1);
 
-		// Copy results from kernel memory into userspace virtual memory
+		/* Copy results from kernel memory into userspace virtual memory */
 		err = copy_to_user(&aperfs[core], &args.aperf, sizeof(u64));
 		if (err != 0) {
 			printk("copy_to_user failed with %lu\n", err);
@@ -223,7 +224,7 @@ asmlinkage int sys_krun_configure(int n_cores) {
 		/* All of the flags are in the lower 32-bits of the MSR */
 		lo |= (EN1_OS | EN1_USR);
 		if (ctrs_version >= 3) {
-			// ANYTHR flag available only after performance counters v3
+			/* ANYTHR flag available only after performance counters v3 */
 			lo |= EN1_ANYTHR;
 		}
 

--- a/krun/krun_reg.h
+++ b/krun/krun_reg.h
@@ -17,31 +17,42 @@
  * Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-/* MSRs */
+/*
+ * MSRs
+ */
 #define IA32_APERF		0xe8
 #define IA32_MPERF		0xe7
 #define IA32_PERF_FIXED_CTR1	0x30a
 #define IA32_FIXED_CTR_CTRL	0x38d
 #define IA32_PERF_GLOBAL_CTRL	0x38f
 
-/* Fields of the IA32_FIXED_CTR_CTRL MSR */
-// Enable couting in ring 0
+/*
+ * Fields of the IA32_FIXED_CTR_CTRL MSR
+ */
+/* Enable couting in ring 0 */
 #define EN1_OS		1 << 4
-// Enable counting in higher rings
+/* Enable counting in higher rings */
 #define EN1_USR		1 << 5
-// Enable counting for all core threads (if any)
+/* Enable counting for all core threads (if any) */
 #define EN1_ANYTHR	1 << 6
 
-/* Fields of the IA32_PERF_GLOBAL_CTRL MSR */
-// Enable IA32_PERF_FIXED_CTR1
-#define EN_FIXED_CTR1	1 << 1  // in the top 32-bits
+/*
+ * Fields of the IA32_PERF_GLOBAL_CTRL MSR
+ */
+/* Enable IA32_PERF_FIXED_CTR1 */
+#define EN_FIXED_CTR1	1 << 1  /* in the top 32-bits */
 
-/* Architectural performance counter CPUID leaf */
+/* CPUID leaves */
 #define	CPUID_ARCH_PERF_CTRS		0x0a
 
-/* Fields of EAX after querying CPUID_ARCH_PERF_CTRS */
-// Architectural performance counters version
+/*
+ * Fields of EAX after querying CPUID_ARCH_PERF_CTRS
+ */
+/* Architectural performance counters version */
 #define CPUID_ARCH_PERF_CTRS_VERS	0xff
-/* Fields of EDX after querying CPUID_ARCH_PERF_CTRS */
-// Fixed-function performance counters bit-width
+
+/*
+ * Fields of EDX after querying CPUID_ARCH_PERF_CTRS
+ */
+/* Fixed-function performance counters bit-width */
 #define CPUID_FIXED_PERF_CTRS_WIDTH	0x1fe0

--- a/krun/krun_reg.h
+++ b/krun/krun_reg.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2017, King's College London.
+ * Created by the Software Development Team <http://soft-dev.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* MSRs */
+#define IA32_APERF		0xe8
+#define IA32_MPERF		0xe7
+#define IA32_PERF_FIXED_CTR1	0x30a
+#define IA32_FIXED_CTR_CTRL	0x38d
+#define IA32_PERF_GLOBAL_CTRL	0x38f
+
+/* Fields of the IA32_FIXED_CTR_CTRL MSR */
+// Enable couting in ring 0
+#define EN1_OS		1 << 4
+// Enable counting in higher rings
+#define EN1_USR		1 << 5
+// Enable counting for all core threads (if any)
+#define EN1_ANYTHR	1 << 6
+
+/* Fields of the IA32_PERF_GLOBAL_CTRL MSR */
+// Enable IA32_PERF_FIXED_CTR1
+#define EN_FIXED_CTR1	1 << 1  // in the top 32-bits
+
+/* Architectural performance counter CPUID leaf */
+#define	CPUID_ARCH_PERF_CTRS		0x0a
+
+/* Fields of EAX after querying CPUID_ARCH_PERF_CTRS */
+// Architectural performance counters version
+#define CPUID_ARCH_PERF_CTRS_VERS	0xff
+/* Fields of EDX after querying CPUID_ARCH_PERF_CTRS */
+// Fixed-function performance counters bit-width
+#define CPUID_FIXED_PERF_CTRS_WIDTH	0x1fe0

--- a/krun/test_prog.c
+++ b/krun/test_prog.c
@@ -56,11 +56,11 @@ int get_ctr1_width(void) {
 	int width;
 
 	asm volatile(
-	    "mov %2, %%eax\n\t"       	// pctr leaf
+	    "mov %2, %%eax\n\t"
 	    "cpuid\n\t"
-	    : "=a" (eax), "=d" (edx)    // out
-	    : "i"(CPUID_ARCH_PERF_CTRS) // in
-	    : "ebx", "ecx");            // clobber
+	    : "=a" (eax), "=d" (edx)    /* out */
+	    : "i"(CPUID_ARCH_PERF_CTRS) /* in*/
+	    : "ebx", "ecx");            /* clobber */
 	width = (edx & CPUID_FIXED_PERF_CTRS_WIDTH) >> 5;
 	printf("ctr1 width is %d\n", width);
 	return width;
@@ -125,7 +125,7 @@ void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs,
 			printf("mperf: %016" PRIu64 "    ", mperfs[idx][core]);
 			printf("ctr1 : %016" PRIu64 "\n", ctr1s[idx][core]);
 
-			// check they make sense too
+			/* check they make sense too */
 			if (aperfs[0][core] > aperfs[1][core]) {
 				err(EXIT_FAILURE, "bad aperfs");
 			}
@@ -157,7 +157,7 @@ int main(void)
 	syscall(__NR_krun_configure, n_cores);
 	syscall(__NR_krun_reset_msrs, n_cores);
 
-	// continually read MSRs
+	/* continually read MSRs */
 	while (true) {
 		printf("Sampling MSRs. Press CTRL+C to stop.\n");
 		read_msrs_checked(n_cores, false, aperfs[0], mperfs[0], ctr1s[0]);
@@ -167,6 +167,6 @@ int main(void)
 		usleep(1 * 1000 * 500);
 		printf("\n");
 	}
-	// unreachable
+	/* unreachable */
 	return 0;
 }

--- a/krun/test_prog.c
+++ b/krun/test_prog.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2017, King's College London.
+ * Created by the Software Development Team <http://soft-dev.org/>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <stdio.h>
+#include <linux/kernel.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include <err.h>
+#include <asm/unistd.h>
+
+/* protos */
+void read_msrs_checked(int n_cores, bool ctr1_first, u_int64_t *aperfs,
+    u_int64_t *mperfs, u_int64_t *ctr1s);
+u_int64_t **alloc_array(int n_cores);
+void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs, u_int64_t **ctr1s);
+int get_ctr1_width(void);
+void mask_ctr1s(int n_cores, u_int64_t **ctr1s);
+
+/* ctr1 is variable size */
+u_int64_t ctr1_mask = 0;
+
+int get_ctr1_width(void) {
+	uint32_t eax, edx;
+	int width;
+
+	asm volatile(
+	    "mov $0xa, %%eax\n\t"       // pctr leaf
+	    "cpuid\n\t"
+	    : "=a" (eax), "=d" (edx)    // out
+	    :                           // in
+	    : "ebx", "ecx");            // clobber
+	width = (edx & 0x1fe0) >> 5;
+	printf("ctr1 width is %d\n", width);
+	return width;
+}
+
+void read_msrs_checked(int n_cores, bool ctr1_first, u_int64_t *aperfs,
+    u_int64_t *mperfs, u_int64_t *ctr1s)
+{
+	int err = syscall(__NR_krun_read_msrs, n_cores, ctr1_first, aperfs, mperfs, ctr1s);
+	if (err != 0) {
+		printf("syscall returned: %ld\n", err);
+		exit(err);
+    }
+}
+
+/* allocates space for 2 readings of one performance counter for all cores */
+u_int64_t **alloc_array(int n_cores)
+{
+	u_int64_t **arr;
+	int i;
+
+	arr = calloc(2, sizeof(u_int64_t *));
+	if (arr == NULL) {
+		printf("failed to allocate\n");
+		exit(EXIT_FAILURE);
+	}
+
+	for (i = 0; i < 2; i++) {
+		arr[i] = calloc(n_cores, sizeof(u_int64_t));
+		if (arr[i] == NULL) {
+			printf("failed to allocate\n");
+			exit(EXIT_FAILURE);
+		}
+	}
+	return arr;
+}
+
+/* apply masking to ctr1s */
+void mask_ctr1s(int n_cores, u_int64_t **ctr1s)
+{
+	int core;
+
+	for (core = 0; core < n_cores; core++) {
+		ctr1s[0][core] &= ctr1_mask;
+		ctr1s[1][core] &= ctr1_mask;
+	}
+}
+
+/* print before and after readings for all counters */
+void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs, u_int64_t **ctr1s)
+{
+	int core, idx;
+
+	for (idx = 0; idx < 2; idx++) {
+		if (!idx) {
+			printf("Before:\n");
+		} else {
+			printf("After:\n");
+		}
+		for (core = 0; core < n_cores; core++) {
+			printf("  core: %02d: aperf: %016" PRIu64 "    ", core, aperfs[idx][core]);
+			printf("mperf: %016" PRIu64 "    ", mperfs[idx][core]);
+			printf("ctr1 : %016" PRIu64 "\n", ctr1s[idx][core]);
+
+			// check they make sense too
+			if (aperfs[0][core] > aperfs[1][core]) {
+				errx(1, "bad aperfs");
+			}
+			if (mperfs[0][core] > mperfs[1][core]) {
+				errx(1, "bad mperfs");
+			}
+			if (ctr1s[0][core] > ctr1s[1][core]) {
+				errx(1, "bad ctr1");
+			}
+		}
+	}
+}
+
+int main(void)
+{
+	u_int64_t **aperfs, **mperfs, **ctr1s;
+	int core, i, n_cores;
+
+	ctr1_mask = ((u_int64_t) 1 << get_ctr1_width()) - 1;
+	printf("ctr1 mask is %" PRIx64 "\n", ctr1_mask);
+	n_cores = sysconf(_SC_NPROCESSORS_ONLN);
+
+	/* make space for readings */
+	aperfs = alloc_array(n_cores);
+	mperfs = alloc_array(n_cores);
+	ctr1s = alloc_array(n_cores);
+
+	printf("configuring for %d cores\n", n_cores);
+	syscall(__NR_krun_configure, n_cores);
+	syscall(__NR_krun_reset_msrs, n_cores);
+
+	// continually read MSRs
+	while (true) {
+		printf("Sampling MSRs. Press CTRL+C to stop.\n");
+		read_msrs_checked(n_cores, false, aperfs[0], mperfs[0], ctr1s[0]);
+		read_msrs_checked(n_cores, true, aperfs[1], mperfs[1], ctr1s[1]);
+		mask_ctr1s(n_cores, ctr1s);
+		print_arrays(n_cores, aperfs, mperfs, ctr1s);
+		usleep(1 * 1000 * 500);
+		printf("\n");
+	}
+	// unreachable
+	return 0;
+}

--- a/krun/test_prog.c
+++ b/krun/test_prog.c
@@ -57,11 +57,10 @@ int get_ctr1_width(void) {
 void read_msrs_checked(int n_cores, bool ctr1_first, u_int64_t *aperfs,
     u_int64_t *mperfs, u_int64_t *ctr1s)
 {
-	int err = syscall(__NR_krun_read_msrs, n_cores, ctr1_first, aperfs, mperfs, ctr1s);
-	if (err != 0) {
-		printf("syscall returned: %ld\n", err);
-		exit(err);
-    }
+	int rv = syscall(__NR_krun_read_msrs, n_cores, ctr1_first, aperfs, mperfs, ctr1s);
+	if (rv != 0) {
+		err(EXIT_FAILURE, "krun_read_msrs failed");
+	}
 }
 
 /* allocates space for 2 readings of one performance counter for all cores */
@@ -72,15 +71,13 @@ u_int64_t **alloc_array(int n_cores)
 
 	arr = calloc(2, sizeof(u_int64_t *));
 	if (arr == NULL) {
-		printf("failed to allocate\n");
-		exit(EXIT_FAILURE);
+		errx(EXIT_FAILURE, "calloc");
 	}
 
 	for (i = 0; i < 2; i++) {
 		arr[i] = calloc(n_cores, sizeof(u_int64_t));
 		if (arr[i] == NULL) {
-			printf("failed to allocate\n");
-			exit(EXIT_FAILURE);
+			errx(EXIT_FAILURE, "calloc");
 		}
 	}
 	return arr;
@@ -115,13 +112,13 @@ void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs, u_int64_t
 
 			// check they make sense too
 			if (aperfs[0][core] > aperfs[1][core]) {
-				errx(1, "bad aperfs");
+				err(EXIT_FAILURE, "bad aperfs");
 			}
 			if (mperfs[0][core] > mperfs[1][core]) {
-				errx(1, "bad mperfs");
+				err(EXIT_FAILURE, "bad mperfs");
 			}
 			if (ctr1s[0][core] > ctr1s[1][core]) {
-				errx(1, "bad ctr1");
+				err(EXIT_FAILURE, "bad ctr1");
 			}
 		}
 	}

--- a/krun/test_prog.c
+++ b/krun/test_prog.c
@@ -132,7 +132,7 @@ void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs,
 int main(void)
 {
 	u_int64_t **aperfs, **mperfs, **ctr1s;
-	int core, i, n_cores;
+	int n_cores;
 
 	ctr1_mask = ((u_int64_t) 1 << get_ctr1_width()) - 1;
 	printf("ctr1 mask is %" PRIx64 "\n", ctr1_mask);

--- a/krun/test_prog.c
+++ b/krun/test_prog.c
@@ -30,6 +30,16 @@
 
 #include "krun_reg.h"
 
+/*
+ * For testing when you don't have the libc-dev headers installed, you can
+ * uncomment these macros. These must stay in-sync with the syscall table.
+ */
+#if 0
+#define __NR_krun_read_msrs	332
+#define __NR_krun_reset_msrs	333
+#define __NR_krun_configure	334
+#endif
+
 /* protos */
 void read_msrs_checked(int n_cores, bool ctr1_first, u_int64_t *aperfs,
     u_int64_t *mperfs, u_int64_t *ctr1s);


### PR DESCRIPTION
Here are the customisations for Linux-4.9.0, as used by Debian 9.

As you know, I was having some issues getting the core-cycle counter to work, and this led me to be a little more defensive/robust in the code. As such this isn't a direct port from 3.16, as such. It contains a handful of improvements.

So that you can see the stuff that changed from 3.16, here is a diff to the `krun/` directory of the `3.16.36-krun` branch. Although we could back-port some of this stuff, I don't think it's worth doing so, as we will never use, nor recommend to others, Debian 8 or the older kernel ever again.

Here's the diff:
```diff
diff --git a/krun/Makefile b/krun/Makefile
index 8f4a7880634b..d5827eef2743 100644
--- a/krun/Makefile
+++ b/krun/Makefile
@@ -1,5 +1,6 @@
 obj-y := krun.o
 
 test_prog: test_prog.c
+	${CC} ${CFLAGS} ${LDFLAGS} -Wall -Wextra -o $@ $<
 clean:
 	rm -f test_prog
diff --git a/krun/krun.c b/krun/krun.c
index 7cdb9c078a9b..6599b7c1d8fe 100644
--- a/krun/krun.c
+++ b/krun/krun.c
@@ -26,6 +26,8 @@
 #include <asm/msr.h>
 #include <linux/uaccess.h>
 
+#include "krun_reg.h"
+
 /* protos */
 void krun_read_msrs(void *data);
 void krun_reset_msrs(void *ununsed);
@@ -33,23 +35,7 @@ asmlinkage int sys_krun_read_msrs(int n_cores, bool ctr1_first, u64 *aperfs,
     u64 *mperfs, u64 *ctr1s);
 asmlinkage void sys_krun_reset_msrs(int n_cores);
 asmlinkage int sys_krun_configure(int n_cores);
-
-/* MSRs */
-#define IA32_APERF		0xe8
-#define IA32_MPERF		0xe7
-#define IA32_PERF_FIXED_CTR1	0x30a
-#define IA32_FIXED_CTR_CTRL	0x38d
-
-/*
- * Bitfields of MSR_IA32_FIXED_CTR_CTRL related to fixed counter 1.
- * AKA, CPU_CLK_UNHLATED.CORE in the Intel manual.
- */
-// Enable couting in ring 0
-#define EN1_OS		1 << 4
-// Enable counting in higer rings
-#define EN1_USR		1 << 5
-// Enable counting for all core threads (if any)
-#define EN1_ANYTHR	1 << 6
+u8 krun_get_arch_perf_ctr_version(void);
 
 /* For passing args to krun_read_msrs() */
 struct krun_msr_args {
@@ -103,10 +89,10 @@ void krun_read_msrs(void *data)
 /* Reset the MSRs of interest on the current CPU core */
 void krun_reset_msrs(void *ununsed)
 {
-    /*
-     * Note we reset MPERF before APERF, so that APERF can never be greater
-     * than MPERF.
-     */
+	/*
+	 * Note we reset MPERF before APERF, so that APERF can never be greater
+	 * than MPERF.
+	 */
 	asm volatile(
 	    "xor %%eax, %%eax\n\t"
 	    "xor %%edx, %%edx\n\t"
@@ -121,6 +107,21 @@ void krun_reset_msrs(void *ununsed)
 	    :"eax", "ecx", "edx");	// clobber
 }
 
+u8
+krun_get_arch_perf_ctr_version()
+{
+	u32 eax;
+
+	asm volatile(
+	    "mov %1, %%eax\n\t"
+	    "cpuid\n\t"
+	    : "=a" (eax)			// out
+	    : "i"(CPUID_ARCH_PERF_CTRS) 	// in
+	    :"ebx", "ecx", "edx");		// clobber
+
+	return eax & CPUID_ARCH_PERF_CTRS_VERS;
+}
+
 /* ------------------------
  * System call entry points
  * ------------------------
@@ -195,8 +196,25 @@ asmlinkage int sys_krun_configure(int n_cores) {
 	 */
 	u32 hi, lo;
 	int err, core;
+	u8 ctrs_version;
 
+	ctrs_version = krun_get_arch_perf_ctr_version();
 	for (core = 0; core < n_cores; core++) {
+		/* Turn on the counter */
+		err = rdmsr_safe_on_cpu(core, IA32_PERF_GLOBAL_CTRL, &lo, &hi);
+		if (err) {
+			printk("problem reading IA32_PERF_GLOBAL_CTRL\n");
+			return err;
+		}
+		hi |= EN_FIXED_CTR1;
+
+		err = wrmsr_safe_on_cpu(core, IA32_PERF_GLOBAL_CTRL, lo, hi);
+		if (err) {
+			printk("problem writing IA32_PERF_GLOBAL_CTRL\n");
+			return err;
+		}
+
+		/* Define what is being counted */
 		err = rdmsr_safe_on_cpu(core, IA32_FIXED_CTR_CTRL, &lo, &hi);
 		if (err) {
 			printk("problem reading IA32_FIXED_CTR_CTRL\n");
@@ -204,7 +222,11 @@ asmlinkage int sys_krun_configure(int n_cores) {
 		}
 
 		/* All of the flags are in the lower 32-bits of the MSR */
-		lo |= (EN1_OS | EN1_USR | EN1_ANYTHR);
+		lo |= (EN1_OS | EN1_USR);
+		if (ctrs_version >= 3) {
+			// ANYTHR flag available only after performance counters v3
+			lo |= EN1_ANYTHR;
+		}
 
 		err = wrmsr_safe_on_cpu(core, IA32_FIXED_CTR_CTRL, lo, hi);
 		if (err) {
diff --git a/krun/krun_reg.h b/krun/krun_reg.h
new file mode 100644
index 000000000000..a23670ab8cc2
--- /dev/null
+++ b/krun/krun_reg.h
@@ -0,0 +1,47 @@
+/*
+ * Copyright (C) 2017, King's College London.
+ * Authored by Edd Barrett <vext01@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/* MSRs */
+#define IA32_APERF		0xe8
+#define IA32_MPERF		0xe7
+#define IA32_PERF_FIXED_CTR1	0x30a
+#define IA32_FIXED_CTR_CTRL	0x38d
+#define IA32_PERF_GLOBAL_CTRL	0x38f
+
+/* Fields of the IA32_FIXED_CTR_CTRL MSR */
+// Enable couting in ring 0
+#define EN1_OS		1 << 4
+// Enable counting in higer rings
+#define EN1_USR		1 << 5
+// Enable counting for all core threads (if any)
+#define EN1_ANYTHR	1 << 6
+
+/* Fields of the IA32_PERF_GLOBAL_CTRL MSR */
+// Enable IA32_PERF_FIXED_CTR1
+#define EN_FIXED_CTR1	1 << 1  // in the top 32-bits
+
+/* Architectural performance counter CPUID leaf */
+#define	CPUID_ARCH_PERF_CTRS		0x0a
+
+/* Fields of EAX after querying CPUID_ARCH_PERF_CTRS */
+// Architectural performance counters version
+#define CPUID_ARCH_PERF_CTRS_VERS	0xff
+/* Fields of EDX after querying CPUID_ARCH_PERF_CTRS */
+// Fixed-function performance counters bit-width
+#define CPUID_FIXED_PERF_CTRS_WIDTH	0x1fe0
diff --git a/krun/test_prog.c b/krun/test_prog.c
index 2d81959c7b20..04f1df7292c9 100644
--- a/krun/test_prog.c
+++ b/krun/test_prog.c
@@ -1,3 +1,22 @@
+/*
+ * Copyright (C) 2017, King's College London.
+ * Authored by Edd Barrett <vext01@gmail.com>.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #include <stdio.h>
 #include <linux/kernel.h>
 #include <sys/syscall.h>
@@ -9,6 +28,18 @@
 #include <err.h>
 #include <asm/unistd.h>
 
+#include "krun_reg.h"
+
+/*
+ * For testing when you don't have the libc-dev headers installed, you can
+ * uncomment these macros. These must stay in-sync with the syscall table.
+ */
+#if 0
+#define __NR_krun_read_msrs	332
+#define __NR_krun_reset_msrs	333
+#define __NR_krun_configure	334
+#endif
+
 /* protos */
 void read_msrs_checked(int n_cores, bool ctr1_first, u_int64_t *aperfs,
     u_int64_t *mperfs, u_int64_t *ctr1s);
@@ -25,12 +56,12 @@ int get_ctr1_width(void) {
 	int width;
 
 	asm volatile(
-	    "mov $0xa, %%eax\n\t"       // pctr leaf
+	    "mov %2, %%eax\n\t"       	// pctr leaf
 	    "cpuid\n\t"
 	    : "=a" (eax), "=d" (edx)    // out
-	    :                           // in
+	    : "i"(CPUID_ARCH_PERF_CTRS) // in
 	    : "ebx", "ecx");            // clobber
-	width = (edx & 0x1fe0) >> 5;
+	width = (edx & CPUID_FIXED_PERF_CTRS_WIDTH) >> 5;
 	printf("ctr1 width is %d\n", width);
 	return width;
 }
@@ -38,11 +69,11 @@ int get_ctr1_width(void) {
 void read_msrs_checked(int n_cores, bool ctr1_first, u_int64_t *aperfs,
     u_int64_t *mperfs, u_int64_t *ctr1s)
 {
-	int err = syscall(__NR_krun_read_msrs, n_cores, ctr1_first, aperfs, mperfs, ctr1s);
-	if (err != 0) {
-		printf("syscall returned: %ld\n", err);
-		exit(err);
-    }
+	int rv = syscall(__NR_krun_read_msrs, n_cores, ctr1_first, aperfs,
+	    mperfs, ctr1s);
+	if (rv != 0) {
+		err(EXIT_FAILURE, "krun_read_msrs failed");
+	}
 }
 
 /* allocates space for 2 readings of one performance counter for all cores */
@@ -53,15 +84,13 @@ u_int64_t **alloc_array(int n_cores)
 
 	arr = calloc(2, sizeof(u_int64_t *));
 	if (arr == NULL) {
-		printf("failed to allocate\n");
-		exit(EXIT_FAILURE);
+		errx(EXIT_FAILURE, "calloc");
 	}
 
 	for (i = 0; i < 2; i++) {
 		arr[i] = calloc(n_cores, sizeof(u_int64_t));
 		if (arr[i] == NULL) {
-			printf("failed to allocate\n");
-			exit(EXIT_FAILURE);
+			errx(EXIT_FAILURE, "calloc");
 		}
 	}
 	return arr;
@@ -79,7 +108,8 @@ void mask_ctr1s(int n_cores, u_int64_t **ctr1s)
 }
 
 /* print before and after readings for all counters */
-void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs, u_int64_t **ctr1s)
+void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs,
+    u_int64_t **ctr1s)
 {
 	int core, idx;
 
@@ -90,19 +120,20 @@ void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs, u_int64_t
 			printf("After:\n");
 		}
 		for (core = 0; core < n_cores; core++) {
-			printf("  core: %02d: aperf: %016" PRIu64 "    ", core, aperfs[idx][core]);
+			printf("  core: %02d: aperf: %016" PRIu64 "    ",
+			    core, aperfs[idx][core]);
 			printf("mperf: %016" PRIu64 "    ", mperfs[idx][core]);
 			printf("ctr1 : %016" PRIu64 "\n", ctr1s[idx][core]);
 
 			// check they make sense too
 			if (aperfs[0][core] > aperfs[1][core]) {
-				errx(1, "bad aperfs");
+				err(EXIT_FAILURE, "bad aperfs");
 			}
 			if (mperfs[0][core] > mperfs[1][core]) {
-				errx(1, "bad mperfs");
+				err(EXIT_FAILURE, "bad mperfs");
 			}
 			if (ctr1s[0][core] > ctr1s[1][core]) {
-				errx(1, "bad ctr1");
+				err(EXIT_FAILURE, "bad ctr1");
 			}
 		}
 	}
@@ -111,7 +142,7 @@ void print_arrays(int n_cores, u_int64_t **aperfs, u_int64_t **mperfs, u_int64_t
 int main(void)
 {
 	u_int64_t **aperfs, **mperfs, **ctr1s;
-	int core, i, n_cores;
+	int n_cores;
 
 	ctr1_mask = ((u_int64_t) 1 << get_ctr1_width()) - 1;
 	printf("ctr1 mask is %" PRIx64 "\n", ctr1_mask);
@@ -122,6 +153,7 @@ int main(void)
 	mperfs = alloc_array(n_cores);
 	ctr1s = alloc_array(n_cores);
 
+	printf("configuring for %d cores\n", n_cores);
 	syscall(__NR_krun_configure, n_cores);
 	syscall(__NR_krun_reset_msrs, n_cores);
```

See individual commit messages for more detail.

Tested on a spare machine with the example config. As it happens, the machine had turbo mode enabled, and Krun noticed this, so I am happy the a/mperf code is right.

Here is the results file I collected using this kernel:
http://theunixzoo.co.uk/random/example_results.json.bz2

And some plots showing the cycle counter working:
http://theunixzoo.co.uk/random/example.pdf

OK? Comments?