### PR TITLE
Simplify Kernel Build Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ regular tick interrupts where possible (for all but the boot CPU core).
    (except CPU 0)` (internally `NO_HZ_FULL_ALL`).
 
  * Go back to the top-level menu and find `General setup->Local Version` and
-   type in a meaningful name. As tempting as it is, *do not* use symbols in
-   this name, as it will cause the Debian package build to bomb out. This name
-   will help you identify if the system is running your kernel.
+   type in a meaningful name. This name will help you identify if the system is
+   running your kernel (via `uname -a`). Be careful not to use exotic symbols
+   in this field. Dots work, but underscores and hyphens confuse Debian's
+   package creation tools. When creating our binary packages, we use
+   `krun.<first 6 chars of git hash>`.
 
  * Save and exit.
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@ into measurements.
 
 These instructions assume a Debian Linux system.
 
-Unfortunately, the process of building from source is complicated by the fact
-that Debian customise the Kernel.
-
 ### Step 1: Make Sure You Are on the Right Branch
 
 This branch is for kernel version 4.9.88.
@@ -28,25 +25,7 @@ $ git branch -r | grep krun
 
 Our branches are named `linux-\*-krun`.
 
-### Step 2: Obtain a Patch of the Krun Changes
-
-Since we need to inherit Debian's kernel customisations, we need to take a diff
-of this kernel's changes and apply it to Debian's kernel. The following command
-creates a diff:
-
- $ git diff v4.9.88 > /tmp/krun-4.9.88.diff
-
-### Step 3: Apply the Patch to the Debian Sources
-
-Make sure you have the `linux-source` package installed, and that its version
-corresponds with the Krun branch you are using (check with `dpkg --list | grep
-linux-source`).
-
- $ xzcat /usr/src/linux-source-4.9.tar.xz | tar xf -
- $ cd linux-source-4.9
- $ patch -Ep1 < /tmp/krun-4.9.88.diff
-
-### Step 4: Configure and Build the Kernel
+### Step 2: Configure and Build the Kernel
 
 Krun requires that the kernel is running in "full tickless mode", thus minimising
 regular tick interrupts where possible (for all but the boot CPU core).
@@ -70,7 +49,7 @@ regular tick interrupts where possible (for all but the boot CPU core).
 
  * Run `make bindeb-pkg`
 
-## Step 5: Install and Boot the New Kernel
+## Step 3: Install and Boot the New Kernel
 
 The previous step should have created deb packages in the parent directory. Next:
 
@@ -82,7 +61,7 @@ The previous step should have created deb packages in the parent directory. Next
    -r`. Debian should have set the kernel as the default. If not, you need to
    edit `/etc/default/grub` and run `update-grub` before rebooting again.
 
-## Step 6: Check the Kernel Over
+## Step 4: Check the Kernel Over
 
 Now you are running the Krun kernel. Let's check it all looks OK:
 


### PR DESCRIPTION
I've recently found Debian documentation which says that it's fine to install a kernel from upstream sources directly [0]:

> Can I install and compile a kernel without some Debian-specific tweaking?
>
> Yes.
>
> There's only one common catch: the Debian C libraries are built with the most recent stable releases of the kernel headers.

(Our headers match upstream's so we don't care about the caveat)

Previously we used a convoluted process of generating a patch and applying it to the sources that the `linux-source` Debain package would give you.

By using our patched upstream sources (from this repo) directly, we can make the 6-step build process a 4-step one.

While we are here, I've also realised that `.` is fine in the kernel's local version field. This means we can have more readable kernel ident strings (`4.9.88krun.a1b2c3` instead of `4.9.88kruna1b2c3`).

This should be the last PR before I make our first binary release of the 4.9.88 Krun kernel.

Looks good?

[0]  https://www.debian.org/doc/manuals/debian-faq/ch-kernel.en.html